### PR TITLE
Restructure BotManager logic to use switch cases.

### DIFF
--- a/code/src/Managers/BotManager.ts
+++ b/code/src/Managers/BotManager.ts
@@ -58,72 +58,58 @@ export default class BotManager {
     }
 
     public static async OnInteractionButton(interaction: ButtonInteraction) {
-        const messageInfo: IMessageInfo = await DiscordUtils.ParseInteractionToInfo(interaction);
-        if (interaction.customId == 'onboarding_help') {
-            OnboardingHandler.OnPlacer(messageInfo);
-        } else if (interaction.customId == 'onboarding_diplomacy') {
-            OnboardingHandler.OnStartDiplomacyOnboarding(messageInfo);
-        } else if (interaction.customId == 'onboarding_observe') {
-            OnboardingHandler.OnObserver(messageInfo);
-        } else if (interaction.customId == 'onboarding_development') {
-            OnboardingHandler.OnDevelopment(messageInfo);
-        } else if (interaction.customId == 'diplomacy_invite') {
-            DiplomacyHandler.OnInviteButton(messageInfo);
-        } else if (interaction.customId == 'diplomacy_peek') {
-            DiplomacyHandler.OnPeek(messageInfo);
-        } else if (interaction.customId.startsWith('vote_confirm')) {
-            const id = interaction.customId.split('_')[2];
-            VoteHandler.OnCreateConfirm(messageInfo, id);
-        } else if (interaction.customId.startsWith('vote_destroy')) {
-            const id = interaction.customId.split('_')[2];
-            VoteHandler.OnDestroy(messageInfo, id);
-        } else if (interaction.customId.startsWith('vote_choose')) {
-            const split = interaction.customId.split('_');
-            VoteHandler.OnChoose(messageInfo, [split[2]], split[3]);
-        } else if (interaction.customId.startsWith('application')) {
-            const role = interaction.customId.split('_')[1];
-            ApplicationHandler.OnApplicationStart(messageInfo, role as RoleType);
-        } else if (interaction.customId == 'diplomacy_report') {
-            DiplomacyHandler.OnStartReport(messageInfo);
-        } else if (interaction.customId.startsWith('diplomacy_claim')) {
-            const id = interaction.customId.split('_')[2];
-            DiplomacyHandler.OnClaim(messageInfo, id);
-        } else if (interaction.customId == 'nightswatch') {
-            NightsWatchHandler.OnButton(messageInfo);
-        } else if (interaction.customId.startsWith('coordinate_claim')) {
-            ArtHandler.OnClaimPixel(messageInfo, interaction.customId.split('_')[2]);
+    const messageInfo: IMessageInfo = await DiscordUtils.ParseInteractionToInfo(interaction);
+    const id_parts = interaction.customId.split('_');
+    switch(id_parts[0]) {
+        case 'onboarding': {
+            switch(id_parts[1]) {
+                case 'help': OnboardingHandler.OnPlacer(messageInfo);
+                case 'diplomacy': OnboardingHandler.OnStartDiplomacyOnboarding(messageInfo);
+                case 'observe': OnboardingHandler.OnObserver(messageInfo);
+                case 'development': OnboardingHandler.OnDevelopment(messageInfo);
+            }
+        }
+        case 'diplomacy': {
+            switch(id_parts[1]) {
+                case 'invite': DiplomacyHandler.OnInviteButton(messageInfo);
+                case 'peek': DiplomacyHandler.OnPeek(messageInfo);
+                case 'report': DiplomacyHandler.OnStartReport(messageInfo);
+                case 'claim': DiplomacyHandler.OnClaim(messageInfo, id_parts[2]);
+            }
+        }
+        case 'vote': {
+            switch(id_parts[1]) {
+                case 'confirm': VoteHandler.OnCreateConfirm(messageInfo, id_parts[2]);
+                case 'destroy': VoteHandler.OnDestroy(messageInfo, id_parts[2]);
+                case 'choose': VoteHandler.OnChoose(messageInfo, [id_parts[2]], id_parts[3]);
+            }
+        }
+        case 'application': ApplicationHandler.OnApplicationStart(messageInfo, id_parts[1] as RoleType);
+        case 'nightswatch': NightsWatchHandler.OnButton(messageInfo);
+        case 'coordinate': ArtHandler.OnClaimPixel(messageInfo, id_parts[2]);
         }
     }
 
     public static async OnInteractionModal(interaction: ModalSubmitInteraction) {
-        const messageInfo: IMessageInfo = await DiscordUtils.ParseInteractionToInfo(interaction);
-        if (interaction.customId == 'onboarding_diplomacy') {
-            OnboardingHandler.OnFinishDiplomacyOnboarding(messageInfo);
-        } else if (interaction.customId == 'treaty_custom') {
-            DiplomacyHandler.OnTreaty(messageInfo, interaction.fields.getTextInputValue('text'));
-        } else if (interaction.customId == 'diplomacy_report') {
-            DiplomacyHandler.OnFinishReport(messageInfo);
-        } else if (interaction.customId.startsWith('vote_create_')) {
-            VoteHandler.OnCreatePreview(messageInfo, interaction.customId.split('_')[2]);
-        } else if (interaction.customId.startsWith('nomination')) {
-            const parts = interaction.customId.split('_');
-            NominationHandler.OnModal(messageInfo, parts[1] as NominationAction, parts[2]);
-        } else if (interaction.customId.startsWith('application')) {
-            const parts = interaction.customId.split('_');
-            ApplicationHandler.OnApplicationFinish(messageInfo, parts[1] as RoleType);
+    const messageInfo: IMessageInfo = await DiscordUtils.ParseInteractionToInfo(interaction);
+    const id_parts = interaction.customId.split('_');
+    switch(id_parts[0]) {
+        case 'onboarding': OnboardingHandler.OnFinishDiplomacyOnboarding(messageInfo);
+        case 'diplomacy': DiplomacyHandler.OnFinishReport(messageInfo);
+        case 'vote': VoteHandler.OnCreatePreview(messageInfo, id_parts[2]);
+        case 'nomination': NominationHandler.OnModal(messageInfo, id_parts[1] as NominationAction, id_parts[2]);
+        case 'application': ApplicationHandler.OnApplicationFinish(messageInfo, id_parts[1] as RoleType);
         }
     }
 
     public static async OnInteractionSelectMenu(interaction: SelectMenuInteraction) {
-        const messageInfo: IMessageInfo = await DiscordUtils.ParseInteractionToInfo(interaction);
-        if (interaction.customId == 'diplomacy_invite') {
-            DiplomacyHandler.OnInvite(messageInfo);
-        } else if (interaction.customId == 'onboarding_roles') {
-            OnboardingHandler.OnRoleSelect(messageInfo);
-        } else if (interaction.customId == 'thread_tags') {
-            ThreadHandler.OnTagsSelect(messageInfo);
-        } else if (interaction.customId.startsWith('vote_choose')) {
-            VoteHandler.OnChoose(messageInfo, interaction.values, interaction.customId.split('_')[2]);
+    const messageInfo: IMessageInfo = await DiscordUtils.ParseInteractionToInfo(interaction);
+    const id_parts = interaction.customId.split('_');
+    switch(id_parts[0]) {
+        case 'diplomacy': DiplomacyHandler.OnInvite(messageInfo);
+        case 'onboarding': OnboardingHandler.OnRoleSelect(messageInfo);
+        case 'thread': ThreadHandler.OnTagsSelect(messageInfo);
+        case 'vote': VoteHandler.OnChoose(messageInfo, interaction.values, id_parts[2]);
         }
     }
 


### PR DESCRIPTION
This PR refactors the existing interaction handling logic to use switch statements instead of if-else blocks. This makes the code more concise, easier to read, and it better represents the Interaction categories.

Changes Made:
- Replaced the if-else block with a switch statement that handles each interaction based on its customId.
- Moved the splitting of the customId into a separate variable to make the code more readable.
- Grouped the interactions into categories (onboarding, diplomacy, vote, etc.) for easier management.

Disclaimer: 
I have not tested this code as setting up a Discord Application would require a lot of work. I would greatly appreciate if someone with a test-application available could make sure the functionality is unchanged.