### PR TITLE
Send a message when a invalid template might have been uploaded.

### DIFF
--- a/code/src/Embeds/AutoplacerEmbeds.ts
+++ b/code/src/Embeds/AutoplacerEmbeds.ts
@@ -1,4 +1,5 @@
 import { EmbedBuilder } from 'discord.js';
+import SettingsConstants from "../Constants/SettingsConstants";
 
 export default class AutoplacerEmbeds {
 
@@ -15,5 +16,12 @@ export default class AutoplacerEmbeds {
         }
 
         return embed;
+    }
+
+    public static GetErrorEmbed(old: number, current: number) {
+        return new EmbedBuilder()
+            .setColor(SettingsConstants.COLORS.BAD)
+            .setTitle('Teveel verkeerde pixels!')
+            .setDescription(`Op dit moment zijn er ${current}% correcte pixels geplaatst. Dat is veel meer dan de ${old}% die er even geleden nog waren! Dit kan duiden op een verkeerde template!`);
     }
 }

--- a/code/src/Managers/AutoplacerManager.ts
+++ b/code/src/Managers/AutoplacerManager.ts
@@ -69,7 +69,7 @@ export default class AutoplacerManager {
 
                 const {right, total} = data.payload.completion;
                 const correctPercentage = right/total*100
-                if(correctPercentage < 25 && correctPercentage < this.lastCorrectPercentage - 5) { //just guessing the numbers.
+                if(correctPercentage < this.lastCorrectPercentage - 5) { //5 should be enough
                     const channel = <TextChannel> await DiscordService.FindChannelById('12345678901234567890');
                     channel.send({
                         embeds: [AutoplacerEmbeds.GetErrorEmbed(this.lastCorrectPercentage, correctPercentage)]

--- a/code/src/Managers/AutoplacerManager.ts
+++ b/code/src/Managers/AutoplacerManager.ts
@@ -69,7 +69,7 @@ export default class AutoplacerManager {
 
                 const {right, total} = data.payload.completion;
                 const correctPercentage = right/total*100
-                if(correctPercentage < this.lastCorrectPercentage - 5) { //5 should be enough
+                if(correctPercentage < this.lastCorrectPercentage - 20) { //20 should be enough
                     const channel = <TextChannel> await DiscordService.FindChannelById('12345678901234567890');
                     channel.send({
                         embeds: [AutoplacerEmbeds.GetErrorEmbed(this.lastCorrectPercentage, correctPercentage)]


### PR DESCRIPTION
Sends a message when the percentage of correct pixels lowers by more than 20% in the span of 1 message, so 2.5 seconds.